### PR TITLE
Add field validation for retrieve_list

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,7 +1,7 @@
 1.0.3 (unreleased)
 ==================
 
-- Nothing changed yet.
+- Field validation on retrieve_list to ensure that all filters are valid, otherwise raise a ValidationException
 
 
 1.0.2 (2016-03-29)

--- a/ripozo_sqlalchemy_tests/integration/__init__.py
+++ b/ripozo_sqlalchemy_tests/integration/__init__.py
@@ -3,4 +3,4 @@ from __future__ import division
 from __future__ import print_function
 from __future__ import unicode_literals
 
-from . import alchemymanager, columns, common, pagination, relationships
+from ripozo_sqlalchemy_tests.integration import alchemymanager, columns, common, pagination, relationships

--- a/ripozo_sqlalchemy_tests/unit/__init__.py
+++ b/ripozo_sqlalchemy_tests/unit/__init__.py
@@ -3,4 +3,4 @@ from __future__ import division
 from __future__ import print_function
 from __future__ import unicode_literals
 
-from . import alchemy_manager, session_handlers
+from ripozo_sqlalchemy_tests.unit import alchemy_manager, session_handlers

--- a/ripozo_sqlalchemy_tests/unit/alchemy_manager.py
+++ b/ripozo_sqlalchemy_tests/unit/alchemy_manager.py
@@ -3,6 +3,7 @@ from __future__ import division
 from __future__ import print_function
 from __future__ import unicode_literals
 
+from ripozo.exceptions import ValidationException
 from ripozo_sqlalchemy.alchemymanager import AlchemyManager, NoResultFound, NotFoundException
 
 import mock
@@ -58,3 +59,27 @@ class TestAlchemyManager(unittest2.TestCase):
         session = mock.MagicMock()
         resp = m.queryset(session)
         self.assertTrue(session.query.called)
+
+
+class TestValidateFields(unittest2.TestCase):
+    """AlchemyManager._validate_fields"""
+    def test__when_all_fields_valid__no_exception(self):
+        manager = AlchemyManager(None)
+        resp = manager._validate_fields({'key': 'value', 'key2': 'value2'}, valid_fields=['key', 'key2'])
+        self.assertIsNone(resp)
+
+    def test__when_missing_fields__validation_exception(self):
+        manager = AlchemyManager(None)
+        manager.model = mock.Mock(__name__='name')
+        self.assertRaises(ValidationException,
+                          manager._validate_fields,
+                          {'key': 'value', 'key2': 'value2'},
+                          valid_fields=['key'])
+
+    def test__when_no_valid_fields_kwarg__uses_self_fields(self):
+        class MyManager(AlchemyManager):
+            fields = ['key', 'key2']
+
+        manager = MyManager(None)
+        resp = manager._validate_fields({'key': 'value', 'key2': 'value2'})
+        self.assertIsNone(resp)


### PR DESCRIPTION
- Added new method `_validate_fields` to AlchemyManager that raises an
  exception when the fields are not valid
- retrieve_list validates filters before passing them to sqlalchemy’s
  `filter_by`
- Unittests for `_validate_fields`
- No relative imports in unittest inits
